### PR TITLE
Improved "run" command to start faster and kill hanging tasks on exit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open('README.rst', 'r') as f:
 
 setup(
     name='ecsctl',
-    version='20190702',
+    version='20200106',
     scripts=['ecscli'],
     description='kubectl-style command line client for AWS ECS.',
     long_description=long_description,


### PR DESCRIPTION
1. Instead of waiting 30 sec before connecting to the job - try it every 1sec until it happened.
2. Kill the task once exited from ssh